### PR TITLE
 Changing back deploy.cluster.mode to default value

### DIFF
--- a/src/main/kotlin/ai/digital/integration/server/deploy/tasks/server/CentralConfigurationTask.kt
+++ b/src/main/kotlin/ai/digital/integration/server/deploy/tasks/server/CentralConfigurationTask.kt
@@ -81,7 +81,7 @@ open class CentralConfigurationTask : DefaultTask() {
 
         val clusterYaml = File("${serverDir}/centralConfiguration/deploy-cluster.yaml")
         val clusterYamlMap: MutableMap<String, Any> = mutableMapOf()
-        var mode: String = "full"
+        var mode: String = "default"
         if(DeployServerUtil.isClusterHotStandby(project))
             mode =  "hot-standby"
         clusterYamlMap.putAll(


### PR DESCRIPTION
For newly added tests depening on hot-standby and full mode will be handled in https://github.com/xebialabs/integration-server-gradle-plugin/pull/156/files

Locally tested other cache tests which depend on the prop