### PR TITLE
Upgrade jdk

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ dependencies {
     implementation("org.postgresql:postgresql:${properties["driverVersions.postgres"]}")
 
 
-    testImplementation("io.mockk:mockk:1.9.3")
+    testImplementation("io.mockk:mockk:1.13.5")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.0")
 }
@@ -267,7 +267,6 @@ tasks {
         jvmArgs(listOf("--add-opens=java.base/java.lang=ALL-UNNAMED",
             "--add-opens=java.base/java.util=ALL-UNNAMED"))
     }
-
 
     withType<ValidatePlugins>().configureEach {
         failOnWarning.set(false)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,8 +87,8 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
     withSourcesJar()
     withJavadocJar()
 }
@@ -256,19 +256,24 @@ tasks {
     }
 
     compileKotlin {
-        kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
+        kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     compileTestKotlin {
-        kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
+        kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
     }
+
+    withType<Test>().configureEach {
+        jvmArgs(listOf("--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED"))
+    }
+
 
     withType<ValidatePlugins>().configureEach {
         failOnWarning.set(false)
         enableStricterValidation.set(false)
     }
 }
-
 node {
     version.set("16.17.0")
     yarnVersion.set("1.22.19")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 dockerPluginVersion=0.35.0
 dbUnitVersion=2.4.9
 kotlin=1.8.10
-xlDefaultsPluginVersion=3.0.1
+xlDefaultsPluginVersion=4.1.0-dev.2+S.94128.fb07635
 asciitableVersion=0.3.2
 failsafeVersion=2.4.4
 typesafeConfigVersion=1.4.1


### PR DESCRIPTION
- --add-opens is enabled for CentralConfigurationUtilTest.getEnvTest which uses ProjectBuilder.builder().build() which needs the package to be open.


TODO:
2 tests failing with new error
CentralConfigurationUtilTest
EnvironmentUtilTest